### PR TITLE
Bump setup-java to v3.1.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
   - name: Setup java
     if: ${{ inputs.cache }}
-    uses: actions/setup-java@v3.0.0
+    uses: actions/setup-java@v3.1.0
     with:
       distribution: ${{ inputs.distribution }}
       overwrite-settings: ${{ inputs.overwrite-settings }}


### PR DESCRIPTION
https://github.com/actions/setup-java/releases/tag/v3.1.0

Fixes a caching issue https://github.com/actions/setup-java/issues/295. Seems like they've used an int32 to count bytes, i.e. it fails when restoring more than 2 147 483 647... bytes.

You can see it happening here: https://github.com/tietoevryfs/ias-server/runs/5820428009?check_suite_focus=true (should I worry that my run restores this large of a cache?)