### PR TITLE
Bump setup-java to 3.6.0 and setup-maven to 4.5

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
   - name: Setup java
     if: ${{ inputs.cache }}
-    uses: actions/setup-java@v3.5.0
+    uses: actions/setup-java@v3.6.0
     with:
       distribution: ${{ inputs.distribution }}
       overwrite-settings: ${{ inputs.overwrite-settings }}
@@ -33,6 +33,6 @@ runs:
       cache: ${{ inputs.cache == 'true' && 'maven' || '' }}
 
   - name: Set up Maven
-    uses: stCarolas/setup-maven@v4.4
+    uses: stCarolas/setup-maven@v4.5
     with:
       maven-version: ${{ inputs.maven-version }}


### PR DESCRIPTION
New version of setup-maven upgrades from deprecated Node.js 12