### PR TITLE
chore: pin gh actions versions to latest sha

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
   - name: Setup java
     if: ${{ inputs.cache }}
-    uses: actions/setup-java@v4.5.0
+    uses: actions/setup-java@f4f1212c880fdec8162ea9a6493f4495191887b4
     with:
       distribution: ${{ inputs.distribution }}
       overwrite-settings: ${{ inputs.overwrite-settings }}
@@ -33,6 +33,6 @@ runs:
       cache: ${{ inputs.cache == 'true' && 'maven' || '' }}
 
   - name: Set up Maven
-    uses: stCarolas/setup-maven@v5
+    uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
     with:
       maven-version: ${{ inputs.maven-version }}

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
   steps:
   - name: Setup java
     if: ${{ inputs.cache }}
-    uses: actions/setup-java@f4f1212c880fdec8162ea9a6493f4495191887b4
+    uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
     with:
       distribution: ${{ inputs.distribution }}
       overwrite-settings: ${{ inputs.overwrite-settings }}
@@ -33,6 +33,6 @@ runs:
       cache: ${{ inputs.cache == 'true' && 'maven' || '' }}
 
   - name: Set up Maven
-    uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1
+    uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 #v5
     with:
       maven-version: ${{ inputs.maven-version }}


### PR DESCRIPTION
Avoid security risk of using snapshot version, and instead pin to latest sha commit.